### PR TITLE
Implement log2 using integer-gmp

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -7,6 +7,7 @@
   `FiniteBits`. If you need to invoke `oneBits` on a data type that does not
   have a `FiniteBits` instance (e.g., `Integer`), use the newly added
   `unsafeOneBits` function instead.
+* Generalize `log2` to all `Integral` types with `base` >= 4.15 (GHC >= 9.0).
 
 0.5.3 [2021.02.17]
 ------------------


### PR DESCRIPTION
GHC.Integer.Logarithms provide a fast way to calculates the integer base 2 logarithm of a integer.

It's available since 7.2
http://www.haskell.org/ghc/docs/7.2-latest/html/libraries/integer-gmp-0.3.0.0/GHC-Integer-Logarithms.html
