### PR TITLE
Dependency bump for mtl and transformers

### DIFF
--- a/bits.cabal
+++ b/bits.cabal
@@ -43,8 +43,8 @@ library
   build-depends:
     base         >= 4.3      && < 5,
     bytes        >= 0.11     && < 1,
-    mtl          >= 2.0      && < 2.2,
-    transformers >= 0.2      && < 0.4
+    mtl          >= 2.0      && < 2.3,
+    transformers >= 0.2      && < 0.5
 
   exposed-modules:
     Data.Bits.Coding


### PR DESCRIPTION
`cabal build` succeeds with `mtl-2.2.1` and `transformers-0.4.1.0` though not with tests enabled.  `doctest` doesn't work with `transformers-0.4*` because it depends on GHC.

This is branched from release `v0.3.3` because `master` didn't build for me.
