### PR TITLE
Fix doctests

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -11,7 +11,7 @@ import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHook
 import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose, copyFiles )
 import Distribution.Simple.BuildPaths ( autogenModulesDir )
 import Distribution.Simple.Setup ( BuildFlags(buildVerbosity), Flag(..), fromFlag, HaddockFlags(haddockDistPref))
-import Distribution.Simple.LocalBuildInfo ( withLibLBI, withTestLBI, LocalBuildInfo(), ComponentLocalBuildInfo(componentPackageDeps) )
+import Distribution.Simple.LocalBuildInfo ( withLibLBI, withTestLBI, LocalBuildInfo(buildDir), ComponentLocalBuildInfo(componentPackageDeps) )
 import Distribution.Text ( display )
 import Distribution.Verbosity ( Verbosity, normal )
 import System.FilePath ( (</>) )
@@ -41,6 +41,13 @@ generateBuildModule verbosity pkg lbi = do
     withTestLBI pkg lbi $ \suite suitecfg -> do
       rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
         [ "module Build_" ++ testName suite ++ " where"
+        , ""
+        , "autogen_dir :: String"
+        , "autogen_dir = " ++ show dir
+        , ""
+        , "build_dir :: String"
+        , "build_dir = " ++ show (buildDir lbi)
+        , ""
         , "deps :: [String]"
         , "deps = " ++ (show $ formatdeps (testDeps libcfg suitecfg))
         ]

--- a/bits.cabal
+++ b/bits.cabal
@@ -56,6 +56,7 @@ test-suite doctests
   main-is:        doctests.hs
   ghc-options:    -Wall -threaded
   hs-source-dirs: tests
+  c-sources:      cbits/debruijn.c
 
   if !flag(test-doctests)
     buildable: False

--- a/tests/doctests.hsc
+++ b/tests/doctests.hsc
@@ -15,7 +15,7 @@
 -----------------------------------------------------------------------------
 module Main where
 
-import Build_doctests (deps)
+import Build_doctests (autogen_dir, build_dir, deps)
 import Control.Applicative
 import Control.Monad
 import Data.List
@@ -54,11 +54,12 @@ withUnicode m = m
 main :: IO ()
 main = withUnicode $ getSources >>= \sources -> doctest $
     "-isrc"
-  : "-idist/build/autogen"
+  : ("-i" ++ autogen_dir)
   : "-optP-include"
-  : "-optPdist/build/autogen/cabal_macros.h"
+  : ("-optP" ++ autogen_dir ++ "/cabal_macros.h")
   : "-hide-all-packages"
   : "-Iincludes"
+  : (build_dir ++ "/doctests/doctests-tmp/cbits/debruijn.o")
   : map ("-package="++) deps ++ sources
 
 getSources :: IO [FilePath]


### PR DESCRIPTION
Currently, the `doctests` fail to run because they aren't given `debruijn.o` as an argument, causing the runtime linker to fail to find certain definitions. This PR explicitly provides this as an argument to `doctests`. I've tested with both `cabal-install` and `stack`.