### PR TITLE
Fix off-by-one error in putUnaligned

### DIFF
--- a/src/Data/Bits/Coding.hs
+++ b/src/Data/Bits/Coding.hs
@@ -206,7 +206,7 @@ putAligned m = Coding $ \ k i b ->
 
 -- | 'Put' all the bits without a 'flush'
 putUnaligned :: (MonadPut m, FiniteBits b) => b -> Coding m ()
-putUnaligned b = putBitsFrom (finiteBitSize b) b
+putUnaligned b = putBitsFrom (pred $ finiteBitSize b) b
 {-# INLINE putUnaligned #-}
 
 -- | 'Put' a single bit, emitting an entire 'byte' if the bit buffer is full


### PR DESCRIPTION
Previous behavior:

    > runPutL $ runCoding (putUnaligned (0xABCD :: Word16)) (\_ _ _ -> pure ()) 0 0
    "U\230"

New behavior:

    > runPutL $ runCoding (putUnaligned (0xABCD :: Word16)) (\_ _ _ -> pure ()) 0 0
    "\171\205"